### PR TITLE
not-tool related hosts

### DIFF
--- a/k0sctl-stack-aws3/infra/k0sctl.tf
+++ b/k0sctl-stack-aws3/infra/k0sctl.tf
@@ -1,3 +1,10 @@
+// constants
+locals {
+
+  // only hosts with these roles will be used for k0s
+  k0s_roles = ["controller", "worker"]
+
+}
 
 variable "k0sctl" {
   description = "K0sctl install configuration"
@@ -113,7 +120,7 @@ EOT
     ssh_user : ng.ssh_user
     ssh_port : ng.ssh_port
     ssh_key_path : abspath(local_sensitive_file.ssh_private_key.filename)
-  } if ng.connection == "ssh"]]...))
+  } if contains(local.k0s_roles, ng.role) && ng.connection == "ssh"]]...))
 
 }
 

--- a/k0sctl-stack-aws3/infra/key.tf
+++ b/k0sctl-stack-aws3/infra/key.tf
@@ -5,7 +5,7 @@
 module "key" {
   source = "../../provision/modules/key/ed25519"
 
-  name = "{var.name}-commonkey"
+  name = "${var.name}-commonkey"
   tags = local.tags
 }
 

--- a/k0sctl-stack-aws3/infra/platform.tf
+++ b/k0sctl-stack-aws3/infra/platform.tf
@@ -12,7 +12,6 @@ module "platform" {
   source = "../../provision/modules/platform"
 
   platform_key     = local.unique_used_platforms[count.index]
-  windows_password = var.windows_password
 }
 
 // variables calculated after ami data is pulled

--- a/k0sctl-stack-aws3/infra/variables.tf
+++ b/k0sctl-stack-aws3/infra/variables.tf
@@ -46,9 +46,3 @@ variable "extra_tags" {
   type        = map(string)
   default     = {}
 }
-
-variable "windows_password" {
-  description = "Password to use with windows & winrm"
-  type        = string
-  default     = ""
-}

--- a/launchpad-stack-aws3/infra/key.tf
+++ b/launchpad-stack-aws3/infra/key.tf
@@ -5,7 +5,7 @@
 module "key" {
   source = "../../provision/modules/key/ed25519"
 
-  name = "{var.name}-commonkey"
+  name = "${var.name}-commonkey"
   tags = local.tags
 }
 

--- a/launchpad-stack-aws3/infra/provision.tf
+++ b/launchpad-stack-aws3/infra/provision.tf
@@ -34,7 +34,7 @@ module "provision" {
   ingresses = local.launchpad_ingresses # see launchpad.tf
 
   // firewall rules (should likely merge with an input to allow more flexibility
-  securitygroups = launchpad_securitygroups # see launchpad.tf
+  securitygroups = local.launchpad_securitygroups # see launchpad.tf
 }
 
 // locals calculated after the provision module is run, but before installation using launchpad


### PR DESCRIPTION
- you can now add host roles that should not be used by the tool
- fixed bad key-name
- removed windows features from k0s, which doesn't support windows